### PR TITLE
Input validation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,6 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in interface-dsl.gemspec
 gemspec
 
+gem 'dry-validation'
 gem 'factorymethods'
 gem 'hashie'

--- a/README.md
+++ b/README.md
@@ -47,12 +47,12 @@ class CodeMonkeyAPI
   extend Interface::DSL
 
   # Define some interface
-  interface(:midnight_api) do |api|
+  interface(:midnight_api) do
 
     # Define some endpoint
-    api.defpoint(:emergency_push) do |op|
-      op.describe "Push the code, fall asleep"
-      op.handler MidnightCodingOperation
+    defpoint(:emergency_push) do |op|
+      describe "Push the code, fall asleep"
+      handler  MidnightCodingOperation
     end
   end
 end
@@ -85,10 +85,10 @@ class HumanoidAPI
   extend Interface::DSL
 
   # declare main API
-  interface(:base_functions) do |base_api|
-    base_api.defpoint(:jump) do |op|
-      op.describe "Do jump!"
-      op.handler BaseRobotJump
+  interface(:base_functions) do
+    defpoint(:jump) do
+      describe "Do jump!"
+      handler  BaseRobotJump
     end
   end
 end
@@ -99,10 +99,10 @@ class JumpExtension
   extend Interface::DSL
 
   # declare extended API
-  interface(:jumping) do |ext|
-    ext.defpoint(:on_one_leg) do |op|
-      op.describe "Carefully jumps on one leg"
-      op.handler RobotJumpingMaster
+  interface(:jumping) do
+    defpoint(:on_one_leg) do
+      describe "Carefully jumps on one leg"
+      handler RobotJumpingMaster
     end
   end
 end
@@ -127,13 +127,13 @@ HumanoidAPI.base_functions.weird.jumping.on_one_leg
 
 ## [WIP] Declare contract for input data by means of dry-validation (available in [input-validation branch](https://github.com/o-kurnenkov/interface-dsl/tree/input-validation))
 ```ruby
-  interface(:midnight_api) do |api|
-    api.defpoint(:emergency_push) do |op|
-      op.describe "Push the code, fall asleep"
-      op.handler MidnightCodingOperation
+  interface(:midnight_api) do
+    defpoint(:emergency_push) do
+      describe "Push the code, fall asleep"
+      handler  MidnightCodingOperation
 
       # contract \
-      op.contract Dry::Validation.Schema do
+      contract Dry::Validation.Schema do
         required(:path_to_bed).schema do
           required(:room).filled
         end

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ class CodeMonkeyAPI
     # Define some endpoint
     api.defpoint(:emergency_push) do |op|
       op.describe "Push the code, fall asleep"
-      op.implementation MidnightCodingOperation
+      op.handler MidnightCodingOperation
     end
   end
 end
@@ -88,7 +88,7 @@ class HumanoidAPI
   interface(:base_functions) do |base_api|
     base_api.defpoint(:jump) do |op|
       op.describe "Do jump!"
-      op.implementation BaseRobotJump
+      op.handler BaseRobotJump
     end
   end
 end
@@ -102,7 +102,7 @@ class JumpExtension
   interface(:jumping) do |ext|
     ext.defpoint(:on_one_leg) do |op|
       op.describe "Carefully jumps on one leg"
-      op.implementation RobotJumpingMaster
+      op.handler RobotJumpingMaster
     end
   end
 end
@@ -130,7 +130,7 @@ HumanoidAPI.base_functions.weird.jumping.on_one_leg
   interface(:midnight_api) do |api|
     api.defpoint(:emergency_push) do |op|
       op.describe "Push the code, fall asleep"
-      op.implementation MidnightCodingOperation
+      op.handler MidnightCodingOperation
 
       # contract \
       op.contract Dry::Validation.Schema do

--- a/interface-dsl.gemspec
+++ b/interface-dsl.gemspec
@@ -16,15 +16,18 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end
+
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'hashie'
-  spec.add_runtime_dependency 'dry-configurable'
-  spec.add_runtime_dependency 'factorymethods'
+  spec.add_runtime_dependency 'dry-validation'
 
-  spec.add_development_dependency 'factorymethods'
+  spec.add_runtime_dependency 'hashie', '~> 3.0'
+  spec.add_runtime_dependency 'dry-configurable', '~> 0.3'
+  spec.add_runtime_dependency 'factorymethods', '~> 1.0'
+
+  spec.add_development_dependency 'factorymethods', '~> 1.0'
   spec.add_development_dependency "bundler", "~> 1.13"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/lib/interface.rb
+++ b/lib/interface.rb
@@ -1,4 +1,5 @@
 require 'dry-configurable'
+require 'dry-validation'
 require 'factorymethods'
 
 module Interface

--- a/lib/interface/dsl.rb
+++ b/lib/interface/dsl.rb
@@ -15,7 +15,7 @@ module Interface
       end
 
       interfaces.merge!(name => ::Interface::PortGroup.new(name, self).tap do |group|
-        yield(group)
+        group.instance_eval(&block)
       end)
     end
 
@@ -89,7 +89,7 @@ module Interface
     end
 
     def define_entity(name, &block)
-      ::Interface::PortEntity.new(name).tap { |port| yield(port) }
+      ::Interface::PortEntity.new(name).tap { |port| port.instance_eval(&block) }
     end
   end
 end

--- a/lib/interface/dsl/version.rb
+++ b/lib/interface/dsl/version.rb
@@ -1,5 +1,5 @@
 module Interface
   module Dsl
-    VERSION = "0.1.1"
+    VERSION = "0.1.3"
   end
 end

--- a/lib/interface/port_entity.rb
+++ b/lib/interface/port_entity.rb
@@ -13,8 +13,8 @@ module Interface
     end
 
     def call(*args, &block)
-      if @implementation.nil?
-        fail(WTFError.new("WAT A HECK U DOIN'! THERE'S NO IMPLEMENTATION TO CALL!"))
+      if @handler.nil?
+        fail(WTFError.new("WAT A HECK U DOIN'! THERE'S NO HANDLER TO CALL!"))
       end
 
       if !@contract.nil?
@@ -24,11 +24,11 @@ module Interface
         fail(InvalidInputError.new(errors)) if errors.any?
       end
 
-      @implementation.call(*args, &block)
+      @handler.call(*args, &block)
     end
 
-    def implementation(klass)
-      @implementation = klass
+    def handler(klass)
+      @handler = klass
     end
 
     def contract(validation_schema)
@@ -50,7 +50,7 @@ module Interface
 #{LIM}
 Name:\t#{ name }
 Desc:\t#{        @description    || N_A}
-Responsible:\t#{ @implementation || N_A}
+Responsible:\t#{ @handler || N_A}
 Accepts:\t#{     @arguments      || N_A}
 Returns:
 \tsuccess:\t#{   @returns && @returns.fetch(:success, N_A) || N_A }


### PR DESCRIPTION
Rename `implementation` -> `handler`. Add `operation` method to interface endpoint
resolve #1 